### PR TITLE
Bug 845539 - don't reject numbers like *2 and *8

### DIFF
--- a/PhoneNumber.js
+++ b/PhoneNumber.js
@@ -37,14 +37,18 @@ var PhoneNumber = (function (dataBase) {
    * data. The symbol 'x' is allowed here as valid punctuation since it is often
    * used as a placeholder for carrier codes, for example in Brazilian phone
    * numbers. We also allow multiple '+' characters at the start.
+   *
    * Corresponds to the following:
-   * [digits]{minLengthNsn}|
+   * [digits*#]{minLengthNsn}|
    * plus_sign*
    * (([punctuation]|[star])*[digits]){3,}([punctuation]|[star]|[digits]|[alpha])*
    *
    * The first reg-ex is to allow short numbers (two digits long) to be parsed
-   * if they are entered as "15" etc, but only if there is no punctuation in
-   * them. The second expression restricts the number of digits to three or
+   * if they are entered as "15" etc, but only if they include only symbols
+   * that appear on a keypad. This also supports the Venezuelan numbers *8
+   * and *2.
+   *
+   * The second expression restricts the number of digits to three or
    * more, but then allows them to be in international form, and to have
    * alpha-characters and punctuation. We split up the two reg-exes here and
    * combine them when creating the reg-ex VALID_PHONE_NUMBER_PATTERN itself so
@@ -53,7 +57,7 @@ var PhoneNumber = (function (dataBase) {
    * Note VALID_PUNCTUATION starts with a -, so must be the first in the range.
    */
   const MIN_LENGTH_PHONE_NUMBER
-    = "[" + VALID_DIGITS + "]{" + MIN_LENGTH_FOR_NSN + "}";
+    = "[*#" + VALID_DIGITS + "]{" + MIN_LENGTH_FOR_NSN + "}";
   const VALID_PHONE_NUMBER
     = "[" + PLUS_CHARS + "]*"
     + "(?:[" + VALID_PUNCTUATION + STAR_SIGN + "]*" + "[" + VALID_DIGITS + "]){3,}"


### PR DESCRIPTION
This is a patch under review for the downstream version of PhoneNumber.js in B2G. See https://bugzilla.mozilla.org/show_bug.cgi?id=845539
