### PR TITLE
Fix chilean mobile numbers

### DIFF
--- a/PhoneNumber.js
+++ b/PhoneNumber.js
@@ -436,7 +436,7 @@ var PhoneNumber = (function (dataBase) {
     if (md.nationalPrefixForParsing) {
       // Some regions have specific national prefix parse rules. Apply those.
       var withoutPrefix = number.replace(md.nationalPrefixForParsing,
-                                         md.nationalPrefixTransformRule);
+                                         md.nationalPrefixTransformRule || '');
       ret = ParseNationalNumber(withoutPrefix, md)
       if (ret)
         return ret;

--- a/test.js
+++ b/test.js
@@ -197,6 +197,12 @@ Format("0577-555-555", "IT", "0577555555", "IT", "05 7755 5555", "+39 05 7755 55
 // Telefonica tests
 Format("612123123", "ES", "612123123", "ES", "612 12 31 23", "+34 612 12 31 23");
 
+// Chile mobile number from a landline
+Format("0997654321", "CL", "997654321", "CL", "(99) 765 4321", "+56 99 765 4321");
+
+// Chile mobile number from another mobile number
+Format("997654321", "CL", "997654321", "CL", "(99) 765 4321", "+56 99 765 4321");
+
 // Dialing 911 in the US. This is not a national number.
 CantParse("911", "US");
 


### PR DESCRIPTION
This PR is a fix on a parsing bug that happens for Chilean mobile numbers.

The chilean metadata array has a value for `nationalPrefixForParsing`, but `nationalPrefixTransformRule` is empty.

When parsing the metadata array, `md.nationalPrefixTransformRule` is not created (undefined) and then the replace function at line [438](https://github.com/andreasgal/PhoneNumber.js/blob/master/PhoneNumber.js#L438) inserts `"undefined"` at the beginning of the chilean mobile numbers.
