### PR TITLE
Fix colombian phone numbers without the leading +

### DIFF
--- a/PhoneNumber.js
+++ b/PhoneNumber.js
@@ -453,16 +453,16 @@ var PhoneNumber = (function (dataBase) {
     if (ret)
       return ret;
 
-    // If the number matches the possible numbers of the current region,
-    // return it as a possible number.
-    if (md.possiblePattern.test(number))
-      return new NationalNumber(md, number);
-
     // Now lets see if maybe its an international number after all, but
     // without '+' or the international prefix.
     ret = ParseInternationalNumber(number)
     if (ret)
       return ret;
+
+    // If the number matches the possible numbers of the current region,
+    // return it as a possible number.
+    if (md.possiblePattern.test(number))
+      return new NationalNumber(md, number);
 
     // We couldn't parse the number at all.
     return null;

--- a/test.js
+++ b/test.js
@@ -194,6 +194,9 @@ Format("0451491934", "DE", "451491934", "DE", "0451 491934", "+49 451 491934");
 // Numbers in italy keep the leading 0 in the city code when dialing internationally.
 Format("0577-555-555", "IT", "0577555555", "IT", "05 7755 5555", "+39 05 7755 5555");
 
+// Colombian international number without the leading "+"
+Format("5712234567", "CO", "12234567", "CO", "(1) 2234567", "+57 1 2234567");
+
 // Telefonica tests
 Format("612123123", "ES", "612123123", "ES", "612 12 31 23", "+34 612 12 31 23");
 


### PR DESCRIPTION
Colombian mobile numbers can be called without the leading "+". Google's libphonenumber supports it but PhoneNumber.js doesn't.

The problem is that PhoneNumber.js first checks that the number is a possible national number and if it isn't then it checks if it can be an international number without the leading "+".

The check of possible national numbers more loose than the check of being an international number, so most international numbers without the leading "+" are considered national numbers.
