### PR TITLE
Bug 862232 - China mobile number will remove first 0

### DIFF
--- a/PhoneNumber.js
+++ b/PhoneNumber.js
@@ -19,9 +19,9 @@ var PhoneNumber = (function (dataBase) {
   // we will generate a regular expression from the value, with those special
   // characters as prefix/suffix.
   const META_DATA_ENCODING = ["region",
-                              "^internationalPrefix",
+                              "^(?:internationalPrefix)",
                               "nationalPrefix",
-                              "^nationalPrefixForParsing",
+                              "^(?:nationalPrefixForParsing)",
                               "nationalPrefixTransformRule",
                               "nationalPrefixFormattingRule",
                               "^possiblePattern$",

--- a/test.js
+++ b/test.js
@@ -209,6 +209,9 @@ Format("997654321", "CL", "997654321", "CL", "(99) 765 4321", "+56 99 765 4321")
 // Dialing 911 in the US. This is not a national number.
 CantParse("911", "US");
 
+// China mobile number with a 0 in it
+Format("15955042864", "CN", "15955042864", "CN", "0159 5504 2864", "+86 159 5504 2864");
+
 // Test normalizing numbers. Only 0-9,#* are valid in a phone number.
 Normalize("+ABC # * , 9 _ 1 _0", "+222#*,910");
 Normalize("ABCDEFGHIJKLMNOPQRSTUVWXYZ", "22233344455566677778889999");


### PR DESCRIPTION
Fix for [#862232](https://bugzilla.mozilla.org/show_bug.cgi?id=862232). The `nationalPrefixForParsing` for China is `(1[1279]\d{3})|0`. We make this into a regex by prefixing this with `^`. Because the `|0` the first 0 is matched if the first group is not matched at pos 0.

```
'9990999'.match(/^(1[1279]\d{3})|0/)
["0"]
```

I wrap the regex'es now in a non matching group so we don't have this problem anymore.
