### PR TITLE
Bail if we don't have formats metadata for the number

### DIFF
--- a/PhoneNumber.js
+++ b/PhoneNumber.js
@@ -169,12 +169,14 @@ var PhoneNumber = (function (dataBase) {
           // "$NP" will be replaced by the national prefix, and "$FG" with the
           // first group of numbers.
           var match = number.match(SPLIT_FIRST_GROUP);
-          var firstGroup = match[1];
-          var rest = match[2];
-          var prefix = nationalPrefixFormattingRule;
-          prefix = prefix.replace("$NP", regionMetaData.nationalPrefix);
-          prefix = prefix.replace("$FG", firstGroup);
-          number = prefix + rest;
+          if (match) {
+            var firstGroup = match[1];
+            var rest = match[2];
+            var prefix = nationalPrefixFormattingRule;
+            prefix = prefix.replace("$NP", regionMetaData.nationalPrefix);
+            prefix = prefix.replace("$FG", firstGroup);
+            number = prefix + rest;
+          }
         }
       }
       return (number == "NA") ? null : number;


### PR DESCRIPTION
Fixes the error when parsing 50020940, BR (and possibly more).
