### PR TITLE
Fix MetaData source url.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: PhoneNumberMetadata.js
 	python xml2meta.py $< > $@
 
 PhoneNumberMetadata.xml:
-	curl http://libphonenumber.googlecode.com/svn/trunk/resources/PhoneNumberMetadata.xml > $@
+	curl https://raw.githubusercontent.com/googlei18n/libphonenumber/master/resources/PhoneNumberMetadata.xml > $@
 
 clean:
 	rm -f PhoneNumberMetadata.xml *~


### PR DESCRIPTION
The current URL is linking to a discontinued repository. It be moved to git hub.